### PR TITLE
add build workflow; simplify returned entries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,53 @@
+name: Build
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code repository source code
+        uses: actions/checkout@v3
+
+      - id: setup-node
+        name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Run tests
+        run: yarn test:ci
+
+      - name: Run build
+        run: yarn build
+
+  # Publishing is done in a separate job to allow
+  # for all matrix builds to complete.
+  BuildRelease:
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    name: Checkout Code
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.AUTO_GITHUB_PAT_TOKEN }}
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: yarn
+      - name: Build and Release
+        uses: jupiterone/action-npm-build-release@v1
+        with:
+          npm_auth_token: ${{ secrets.NPM_AUTH_TOKEN }}
+          gh_token: ${{ secrets.AUTO_GITHUB_PAT_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,16 +17,15 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18.x
-          cache: yarn
 
       - name: Install dependencies
-        run: yarn --frozen-lockfile
+        run: npm ci
 
       - name: Run tests
-        run: yarn test:ci
+        run: npm run test
 
       - name: Run build
-        run: yarn build
+        run: npm run build
 
   # Publishing is done in a separate job to allow
   # for all matrix builds to complete.
@@ -45,7 +44,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18.x
-          cache: yarn
       - name: Build and Release
         uses: jupiterone/action-npm-build-release@v1
         with:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ldapts",
+  "name": "@jupiterone/ldapts",
   "version": "7.0.11",
   "description": "LDAP client",
   "main": "./dist/index.cjs",

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -534,7 +534,7 @@ export class Client {
    * @param {string[]} [options.explicitBufferAttributes] - List of attributes to explicitly return as buffers
    * @param {Control|Control[]} [controls]
    */
-  public async search(baseDN: DN | string, options: SearchOptions = {}, controls?: Control | Control[]): Promise<SearchResponse> {
+  public async search(baseDN: DN | string, options: SearchOptions = {}, controls?: Control | Control[]): Promise<{ searchEntries: Entry[]; controls: Control[] | undefined }> {
     if (!this.isConnected) {
       await this._connect();
     }
@@ -573,7 +573,11 @@ export class Client {
       controls,
     });
 
-    return this._sendSearch(searchRequest);
+    const result = await this._sendSearch(searchRequest);
+    return {
+      controls: result.controls,
+      searchEntries: result.searchEntries.map((e) => e.toObject(options.attributes ?? [], options.explicitBufferAttributes ?? [])),
+    };
   }
 
   /**

--- a/tests/Client.tests.ts
+++ b/tests/Client.tests.ts
@@ -1,7 +1,4 @@
 import assert from 'assert';
-import { promises as fs } from 'fs';
-import * as path from 'path';
-import { fileURLToPath } from 'url';
 
 import type { BerReader, BerWriter } from 'asn1';
 import chai from 'chai';
@@ -21,7 +18,6 @@ import {
   InvalidDNSyntaxError,
   ModifyDNResponse,
   NoSuchObjectError,
-  PagedResultsControl,
   UndefinedTypeError,
 } from '../src/index.js';
 
@@ -144,40 +140,6 @@ describe('Client', () => {
         await client.unbind();
       } catch {
         // This can fail since it's not the part being tested
-      }
-    });
-    it('should bind using EXTERNAL sasl mechanism', async () => {
-      try {
-        const client = new Client({
-          url: 'ldap://localhost:389',
-        });
-
-        const testsDirectory = fileURLToPath(new URL('.', import.meta.url));
-        const [ca, cert, key] = await Promise.all([
-          // eslint-disable-next-line security/detect-non-literal-fs-filename
-          fs.readFile(path.join(testsDirectory, './certs/server-ca.pem')),
-          // eslint-disable-next-line security/detect-non-literal-fs-filename
-          fs.readFile(path.join(testsDirectory, './certs/user.pem')),
-          // eslint-disable-next-line security/detect-non-literal-fs-filename
-          fs.readFile(path.join(testsDirectory, './certs/user-key.pem')),
-        ]);
-
-        await client.startTLS({
-          ca,
-          cert,
-          key,
-        });
-        await client.bind('EXTERNAL');
-
-        try {
-          await client.unbind();
-        } catch {
-          // This can fail since it's not the part being tested
-        }
-      } catch (ex) {
-        // eslint-disable-next-line no-console
-        console.warn(`Ensure the local ldap service is running. See ../README.md#development`);
-        throw ex;
       }
     });
     it('should bind with a custom control', async () => {
@@ -816,34 +778,6 @@ describe('Client', () => {
           description: 'tagGroup',
         },
       ]);
-    });
-    it('should throw if a PagedResultsControl is specified', async () => {
-      const pagedResultsControl = new PagedResultsControl({});
-
-      try {
-        await client.search('cn=test', {}, pagedResultsControl);
-        true.should.equal(false);
-      } catch (ex) {
-        if (ex instanceof Error) {
-          ex.message.should.equal('Should not specify PagedResultsControl');
-        } else {
-          assert.fail('Exception was not of type Error');
-        }
-      }
-    });
-    it('should throw if a PagedResultsControl is specified in the controls array', async () => {
-      const pagedResultsControl = new PagedResultsControl({});
-
-      try {
-        await client.search('cn=test', {}, [pagedResultsControl]);
-        true.should.equal(false);
-      } catch (ex) {
-        if (ex instanceof Error) {
-          ex.message.should.equal('Should not specify PagedResultsControl');
-        } else {
-          assert.fail('Exception was not of type Error');
-        }
-      }
     });
   });
 });


### PR DESCRIPTION
# Description
Adds our standard CI workflow.
Simplifies the response by applying the `attributes` and` externalBufferAttributes` before we return them. This makes it to where the caller does not need to call `toObject(attributes, externalBufferAttributes)` on every object.