### PR TITLE
Update release workflow to work with npm + not use auto

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,14 +9,14 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code repository source code
-        uses: actions/checkout@v3
-
       - id: setup-node
         name: Setup Node
         uses: actions/setup-node@v3
         with:
           node-version: 18.x
+
+      - name: Check out code repository source code
+        uses: actions/checkout@v3
 
       - name: Install dependencies
         run: npm ci
@@ -29,23 +29,65 @@ jobs:
 
   # Publishing is done in a separate job to allow
   # for all matrix builds to complete.
-  BuildRelease:
+  release:
     needs: test
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
-    name: Checkout Code
     steps:
-      - name: Check out repo
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.AUTO_GITHUB_PAT_TOKEN }}
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
           node-version: 18.x
-      - name: Build and Release
-        uses: jupiterone/action-npm-build-release@v1
+
+      - name: Check out repo
+        uses: actions/checkout@v3
         with:
-          npm_auth_token: ${{ secrets.NPM_AUTH_TOKEN }}
-          gh_token: ${{ secrets.AUTO_GITHUB_PAT_TOKEN }}
+          fetch-depth: 2
+
+      # Fetch tags and describe the commit before the merge commit
+      # to see if it's a version publish
+      - name: Fetch tags
+        run: |
+          git fetch --tags
+          if git describe --exact-match --match "v*.*.*" HEAD^2
+          then
+            echo "Found version commit tag. Publishing."
+            echo "publish=true" >> $GITHUB_ENV
+            echo "VERSION_NUM=`echo $(git describe --tags --abbrev=0 | sed -e "s/v//gI")`" >> $GITHUB_ENV
+          else
+            echo "Version commit tag not found. Not publishing."
+          fi
+
+      - name: Publish
+        if: env.publish == 'true'
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > .npmrc
+          npm ci
+          npm run build
+          npm publish
+
+      - name: Get Version Changelog Entry
+        if: env.publish == 'true'
+        id: changelog_reader
+        uses: mindsers/changelog-reader-action@v2
+        with:
+          version: ${{ env.VERSION_NUM }}
+          path: ./CHANGELOG.md
+        continue-on-error: true
+
+      - name: Create Release
+        if: env.publish == 'true'
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.changelog_reader.outputs.version }}
+          release_name: Release ${{ steps.changelog_reader.outputs.version }}
+          body: ${{ steps.changelog_reader.outputs.changes }}
+          prerelease:
+            ${{ steps.changelog_reader.outputs.status == 'prereleased' }}
+          draft: ${{ steps.changelog_reader.outputs.status == 'unreleased' }}
+        continue-on-error: true


### PR DESCRIPTION
# Description

It will be difficult to get this repo setup with Auto and since we don't plan on releasing too often the simple commit based versioning should work.